### PR TITLE
Basic support for Python synthax highlighting

### DIFF
--- a/hotbox_designer/designer/attributes.py
+++ b/hotbox_designer/designer/attributes.py
@@ -5,6 +5,7 @@ from hotbox_designer.colorwheel import ColorDialog
 from hotbox_designer.qtutils import icon, VALIGNS, HALIGNS
 from hotbox_designer.widgets import (
     Title, BoolCombo, WidgetToggler, FloatEdit, BrowseEdit, ColorEdit)
+from hotbox_designer.designer.synthaxhighlighting import PythonHighlighter
 
 
 LEFT_CELL_WIDTH = 80
@@ -277,7 +278,7 @@ class AppearenceSettings(QtWidgets.QWidget):
         values = list({option['border'] for option in options})
         value = str(values[0]) if len(values) == 1 else None
         self.border.setCurrentText(value)
-    
+
         values = list({option['borderwidth.normal'] for option in options})
         value = str(values[0]) if len(values) == 1 else None
         self.borderwidth_normal.setText(value)
@@ -340,7 +341,7 @@ class ActionSettings(QtWidgets.QWidget):
         self._llanguage = QtWidgets.QComboBox()
         method = partial(self.language_changed, 'left')
         self._llanguage.currentIndexChanged.connect(method)
-        self._lcommand = QtWidgets.QTextEdit()
+        self._lcommand = QtWidgets.QPlainTextEdit()
         self._lcommand.setFixedHeight(100)
         self._lsave = QtWidgets.QPushButton('save command')
         self._lsave.released.connect(partial(self.save_command, 'left'))
@@ -357,7 +358,7 @@ class ActionSettings(QtWidgets.QWidget):
         self._rlanguage = QtWidgets.QComboBox()
         method = partial(self.language_changed, 'right')
         self._rlanguage.currentIndexChanged.connect(method)
-        self._rcommand = QtWidgets.QTextEdit()
+        self._rcommand = QtWidgets.QPlainTextEdit()
         self._rcommand.setFixedHeight(100)
         self._rsave = QtWidgets.QPushButton('save command')
         self._rsave.released.connect(partial(self.save_command, 'right'))
@@ -381,6 +382,11 @@ class ActionSettings(QtWidgets.QWidget):
         for label in self.findChildren(QtWidgets.QLabel):
             if not isinstance(label, Title):
                 label.setFixedWidth(LEFT_CELL_WIDTH)
+
+        # TODO: set QPlainTextEdit widgets on language_changed signal only
+        # for Python
+        PythonHighlighter(self._lcommand.document())
+        PythonHighlighter(self._rcommand.document())
 
     def set_languages(self, languages):
         self.blockSignals(True)

--- a/hotbox_designer/designer/attributes.py
+++ b/hotbox_designer/designer/attributes.py
@@ -5,7 +5,8 @@ from hotbox_designer.colorwheel import ColorDialog
 from hotbox_designer.qtutils import icon, VALIGNS, HALIGNS
 from hotbox_designer.widgets import (
     Title, BoolCombo, WidgetToggler, FloatEdit, BrowseEdit, ColorEdit)
-from hotbox_designer.designer.synthaxhighlighting import PythonHighlighter
+from hotbox_designer.designer.synthaxhighlighting import (
+    PythonHighlighter, NoHighlighter)
 
 
 LEFT_CELL_WIDTH = 80
@@ -383,11 +384,6 @@ class ActionSettings(QtWidgets.QWidget):
             if not isinstance(label, Title):
                 label.setFixedWidth(LEFT_CELL_WIDTH)
 
-        # TODO: set QPlainTextEdit widgets on language_changed signal only
-        # for Python
-        PythonHighlighter(self._lcommand.document())
-        PythonHighlighter(self._rcommand.document())
-
     def set_languages(self, languages):
         self.blockSignals(True)
         self._llanguage.addItems(languages)
@@ -397,7 +393,13 @@ class ActionSettings(QtWidgets.QWidget):
     def language_changed(self, side, *useless):
         option = 'action.' + side + '.language'
         combo = self._llanguage if side == 'left' else self._rlanguage
-        self.optionSet.emit(option, combo.currentText())
+        text_edit = self._lcommand if side == 'left' else self._rcommand
+        language = combo.currentText()
+        if language == 'python':
+            PythonHighlighter(text_edit.document())
+        else:
+            NoHighlighter(text_edit.document())
+        self.optionSet.emit(option, language)
 
     def save_command(self, side):
         text_edit = self._lcommand if side == 'left' else self._rcommand

--- a/hotbox_designer/designer/synthaxhighlighting.py
+++ b/hotbox_designer/designer/synthaxhighlighting.py
@@ -52,6 +52,14 @@ def create_textcharformat(color, bold=False, italic=False):
     return format
 
 
+class NoHighlighter(QtGui.QSyntaxHighlighter):
+    def __init__(self, parent=None):
+        super(NoHighlighter, self).__init__(parent)
+
+    def highlightBlock(self, text):
+        return
+
+
 class PythonHighlighter(QtGui.QSyntaxHighlighter):
     PATTERNS = {
         'keyword': r'\b|'.join(keyword.kwlist),

--- a/hotbox_designer/designer/synthaxhighlighting.py
+++ b/hotbox_designer/designer/synthaxhighlighting.py
@@ -4,32 +4,32 @@ from PySide2 import QtGui, QtCore
 
 TEXT_STYLES = {
     'keyword': {
-        'color': QtCore.Qt.white,
+        'color': 'white',
         'bold': True,
         'italic': False
     },
     'number': {
-        'color': QtCore.Qt.cyan,
+        'color': 'cyan',
         'bold': False,
         'italic': False
     },
     'comment': {
-        'color': QtCore.Qt.red,
+        'color': (0.7, 0.5, 0.5),
         'bold': False,
         'italic': False
     },
     'function': {
-        'color': QtCore.Qt.green,
+        'color': '#ff0571',
         'bold': False,
         'italic': True
     },
     'string': {
-        'color': QtCore.Qt.yellow,
+        'color': 'yellow',
         'bold': False,
         'italic': False
     },
     'boolean': {
-        'color': QtCore.Qt.darkYellow,
+        'color': '#a18852',
         'bold': True,
         'italic': False
     }
@@ -38,7 +38,13 @@ TEXT_STYLES = {
 
 def create_textcharformat(color, bold=False, italic=False):
     format = QtGui.QTextCharFormat()
-    format.setForeground(color)
+    qcolor = QtGui.QColor()
+    if isinstance(color, str):
+        qcolor.setNamedColor(color)
+    else:
+        r, g, b = color
+        qcolor.setRgbF(r, g, b)
+    format.setForeground(qcolor)
     if bold:
         format.setFontWeight(QtGui.QFont.Bold)
     if italic:

--- a/hotbox_designer/designer/synthaxhighlighting.py
+++ b/hotbox_designer/designer/synthaxhighlighting.py
@@ -1,0 +1,44 @@
+import keyword
+from PySide2 import QtGui, QtCore
+
+
+class PythonHighlighter(QtGui.QSyntaxHighlighter):
+    def __init__(self, parent=None):
+        super(PythonHighlighter, self).__init__(parent)
+        self.rules = []
+
+        keywords = keyword.kwlist
+        number_pattern = r'\b[+-]?[0-9]+[lL]?\b'
+        comment_pattern = r'#[^\n]*'
+        function_pattern = r'\b[A-Za-z0-9_]+(?=\()'
+
+        keyword_format = QtGui.QTextCharFormat()
+        keyword_format.setForeground(QtCore.Qt.white)
+        keyword_format.setFontWeight(QtGui.QFont.Bold)
+        self.rules.extend([
+            (QtCore.QRegExp(word), keyword_format) for word in keywords])
+
+        number_format = QtGui.QTextCharFormat()
+        number_format.setForeground(QtCore.Qt.cyan)
+        self.rules.append(
+            (QtCore.QRegExp(number_pattern), number_format))
+
+        comment_format = QtGui.QTextCharFormat()
+        comment_format.setForeground(QtCore.Qt.lightGray)
+        self.rules.append(
+            (QtCore.QRegExp(comment_pattern), comment_format))
+
+        function_format = QtGui.QTextCharFormat()
+        function_format.setFontItalic(True)
+        function_format.setForeground(QtCore.Qt.yellow)
+        self.rules.append(
+            (QtCore.QRegExp(function_pattern), function_format))
+
+    def highlightBlock(self, text):
+        for pattern, format in self.rules:
+            expression = QtCore.QRegExp(pattern)
+            index = expression.indexIn(text)
+            while index >= 0:
+                length = expression.matchedLength()
+                self.setFormat(index, length, format)
+                index = expression.indexIn(text, index + length)

--- a/hotbox_designer/designer/synthaxhighlighting.py
+++ b/hotbox_designer/designer/synthaxhighlighting.py
@@ -28,6 +28,11 @@ TEXT_STYLES = {
         'bold': False,
         'italic': False
     },
+    'boolean': {
+        'color': QtCore.Qt.darkYellow,
+        'bold': True,
+        'italic': False
+    }
 }
 
 
@@ -43,11 +48,12 @@ def create_textcharformat(color, bold=False, italic=False):
 
 class PythonHighlighter(QtGui.QSyntaxHighlighter):
     PATTERNS = {
-        'keyword': r'|'.join(keyword.kwlist),
+        'keyword': r'\b|'.join(keyword.kwlist),
         'number': r'\b[+-]?[0-9]+[lL]?\b',
         'comment': r'#[^\n]*',
         'function': r'\b[A-Za-z0-9_]+(?=\()',
-        'string': r'".*"|\'.*\''
+        'string': r'".*"|\'.*\'',
+        'boolean': r'\bTrue\b|\bFalse\b'
     }
 
     def __init__(self, parent=None):

--- a/hotbox_designer/designer/synthaxhighlighting.py
+++ b/hotbox_designer/designer/synthaxhighlighting.py
@@ -2,37 +2,66 @@ import keyword
 from PySide2 import QtGui, QtCore
 
 
+TEXT_STYLES = {
+    'keyword': {
+        'color': QtCore.Qt.white,
+        'bold': True,
+        'italic': False
+    },
+    'number': {
+        'color': QtCore.Qt.cyan,
+        'bold': False,
+        'italic': False
+    },
+    'comment': {
+        'color': QtCore.Qt.red,
+        'bold': False,
+        'italic': False
+    },
+    'function': {
+        'color': QtCore.Qt.green,
+        'bold': False,
+        'italic': True
+    },
+    'string': {
+        'color': QtCore.Qt.yellow,
+        'bold': False,
+        'italic': False
+    },
+}
+
+
+def create_textcharformat(color, bold=False, italic=False):
+    format = QtGui.QTextCharFormat()
+    format.setForeground(color)
+    if bold:
+        format.setFontWeight(QtGui.QFont.Bold)
+    if italic:
+        format.setFontItalic(True)
+    return format
+
+
 class PythonHighlighter(QtGui.QSyntaxHighlighter):
+    PATTERNS = {
+        'keyword': r'|'.join(keyword.kwlist),
+        'number': r'\b[+-]?[0-9]+[lL]?\b',
+        'comment': r'#[^\n]*',
+        'function': r'\b[A-Za-z0-9_]+(?=\()',
+        'string': r'".*"|\'.*\''
+    }
+
     def __init__(self, parent=None):
         super(PythonHighlighter, self).__init__(parent)
         self.rules = []
-
-        keywords = keyword.kwlist
-        number_pattern = r'\b[+-]?[0-9]+[lL]?\b'
-        comment_pattern = r'#[^\n]*'
-        function_pattern = r'\b[A-Za-z0-9_]+(?=\()'
-
-        keyword_format = QtGui.QTextCharFormat()
-        keyword_format.setForeground(QtCore.Qt.white)
-        keyword_format.setFontWeight(QtGui.QFont.Bold)
-        self.rules.extend([
-            (QtCore.QRegExp(word), keyword_format) for word in keywords])
-
-        number_format = QtGui.QTextCharFormat()
-        number_format.setForeground(QtCore.Qt.cyan)
-        self.rules.append(
-            (QtCore.QRegExp(number_pattern), number_format))
-
-        comment_format = QtGui.QTextCharFormat()
-        comment_format.setForeground(QtCore.Qt.lightGray)
-        self.rules.append(
-            (QtCore.QRegExp(comment_pattern), comment_format))
-
-        function_format = QtGui.QTextCharFormat()
-        function_format.setFontItalic(True)
-        function_format.setForeground(QtCore.Qt.yellow)
-        self.rules.append(
-            (QtCore.QRegExp(function_pattern), function_format))
+        for name, properties in TEXT_STYLES.items():
+            if name not in self.PATTERNS:
+                continue
+            text_format = create_textcharformat(
+                color=properties['color'],
+                bold=properties['bold'],
+                italic=properties['italic'])
+            self.rules.append(
+                (QtCore.QRegExp(self.PATTERNS[name]), text_format))
 
     def highlightBlock(self, text):
         for pattern, format in self.rules:


### PR DESCRIPTION
There might be a better way to set and unset the QSyntaxHighlighter.
I also changed QTextEdit to QPlainTextEdit which seems more adapted to a scripting area.