### PR TITLE
Switched lines 181-182 in reader.py

### DIFF
--- a/hotbox_designer/reader.py
+++ b/hotbox_designer/reader.py
@@ -178,8 +178,8 @@ class HotboxReader(QtWidgets.QWidget):
         painter.end()
 
     def show(self):
-        super(HotboxReader, self).show()
         self.move(QtGui.QCursor.pos() - self.center)
+        super(HotboxReader, self).show()
         self.setFocus()
 
     def hide(self):


### PR DESCRIPTION
Switched lines 181-182 so the hotbox is positioned before it is shown. This way no popping from the previous position to the new one. A smilar behavior is present in the aiming line. The aiming line center pops from a sort o random position to the current mouse cursor position.