### PR TITLE
fix export dialog for maya 2025

### DIFF
--- a/hotbox_designer/dialog.py
+++ b/hotbox_designer/dialog.py
@@ -43,8 +43,8 @@ def import_hotbox_link():
 
 def export_hotbox(hotbox):
     filenames = QtWidgets.QFileDialog.getSaveFileName(
-        None, caption='Export hotbox', directory=os.path.expanduser("~"),
-        filter='*.json')
+        None, 'Export hotbox', os.path.expanduser("~"),
+        '*.json')
     filename = filenames[0]
     if not filename:
         return


### PR DESCRIPTION
In PySide6, QFileDialog.getSaveFileName() no longer supports the keyword directory.
The correct keyword is dir.
Removing the keywords makes it work in maya 2025 and below.